### PR TITLE
fix(layout): replace .Site.IsServer with hugo.IsServer

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
     {{ partial "head/meta.html" . }}
 
     {{ $styles := resources.Get "/css/dist/style.css" | postCSS }}
-    {{ if .Site.IsServer }}
+    {{ if hugo.IsServer }}
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}" />
     {{ else }}
     {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}
@@ -33,7 +33,7 @@
 
     {{ $js := slice $scripts $hamburger | resources.Concat "js/bundle.js" }}
 
-    {{ if .Site.IsServer }}
+    {{ if hugo.IsServer }}
     <script type="text/javascript" src="{{ $js.RelPermalink }}"></script>
     {{ else }}
     <script type="text/javascript" src="{{ ($js | minify | fingerprint).RelPermalink }}"></script>

--- a/layouts/partials/analytics/google-analytics.html
+++ b/layouts/partials/analytics/google-analytics.html
@@ -1,35 +1,35 @@
-{{- if .Site.IsServer -}}
-    <!-- Dont add Google analytics to localhost -->
-{{ else }}
-    {{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}
-    {{ if $gid }}
-        <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
+{{- if hugo.IsServer -}}
+<!-- Dont add Google analytics to localhost -->
+{{ else }} {{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }} {{ if $gid }}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
 
-          function gtag() {
-            dataLayer.push(arguments);
-          }
+  function gtag() {
+    dataLayer.push(arguments);
+  }
 
-          gtag('js', new Date());
-          gtag('config', '{{- $gid -}}');
-        </script>
-    {{ else }}
-        {{ if .Site.Params.google_analytics_id }}
-            <!-- Global site tag (gtag.js) - Google Analytics -->
-            <script async
-                    src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
-            <script>
-              window.dataLayer = window.dataLayer || [];
+  gtag("js", new Date());
+  gtag("config", "{{- $gid -}}");
+</script>
+{{ else }} {{ if .Site.Params.google_analytics_id }}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
 
-              function gtag() {
-                dataLayer.push(arguments);
-              }
+  function gtag() {
+    dataLayer.push(arguments);
+  }
 
-              gtag('js', new Date());
-              gtag('config', '{{- .Site.Params.google_analytics_id -}}');
-            </script>
-        {{ end }}
-    {{ end}}
-{{ end }}
+  gtag("js", new Date());
+  gtag("config", "{{- .Site.Params.google_analytics_id -}}");
+</script>
+{{ end }} {{ end}} {{ end }}

--- a/layouts/partials/head/styles.html
+++ b/layouts/partials/head/styles.html
@@ -1,7 +1,7 @@
 
 {{ $styles := resources.Get "/css/style.css" | postCSS }}
 
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
   <link rel="stylesheet" href="{{ $styles.RelPermalink }}"/>
 {{ else }}
   {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}


### PR DESCRIPTION
Since a few minor version updates in Hugo, the .Site.IsServer variable has been deprecated. As this variable is now undefined, the theme can not be correctly built due to undefined exception.

This patch replaces the deprecated call to .Site.IsServer with presently available hugo.IsServer call.