### PR TITLE
feat(layouts): post cover images are now optional

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,7 +9,9 @@
 </div>
 {{ end }}
 
+{{ if .Params.image }}
 <img width="1600" height="900" src="{{ .Params.image }}" />
+{{ end }}
 
 <div class="flex flex-col md:flex-row py-6 md:py-12">
 


### PR DESCRIPTION
Previously, the article(post) cover photos were always rendered, which caused a large broken white-space if an image is not provided.

In this patch, the post cover photo(image) is optionally rendered only-if it is defined, otherwise the entire image element is not rendered.